### PR TITLE
Update libc to v0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ build = "build.rs"
 readme = "README.md"
 
 [dev-dependencies]
-libc = "0.1.10"
+libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,35 +10,33 @@ build.rs is passed to those packages.
 
 */
 
-#![allow(non_camel_case_types)]
-
 #[cfg(test)]
 extern crate libc;
 
+#[allow(non_camel_case_types)]
 #[cfg(test)]
 mod tests {
-    use libc::{c_int, c_float};
+    use libc::{c_float, c_long, c_ulong};
 
-    // FIXME: I'm not sure if these next two lines are correct.
-    type vDSP_Stride = c_int;
-    type vDSP_Length = c_int;
+    type vDSP_Length = c_ulong;
+    type vDSP_Stride = c_long;
 
     extern "C" {
-        // Multiply vector __vDSP_A by scalar __vDSP_B and place result in __vDSP_C.
-        pub fn vDSP_vsmul(__vDSP_A: *const c_float, __vDSP_IA: vDSP_Stride, __vDSP_B: *const c_float, __vDSP_C: *mut c_float, __vDSP_IC: vDSP_Stride, __vDSP_N: vDSP_Length );
+        // Vector-scalar multiply.
+        fn vDSP_vsmul(__A: *const c_float, __IA: vDSP_Stride, __B: *const c_float,
+                      __C: *mut c_float, __IC: vDSP_Stride, __N: vDSP_Length);
     }
 
-    fn approx_eq(x: f32, y:f32) -> bool {
+    fn approx_eq(x: c_float, y: c_float) -> bool {
         let eps = 1e-10;
         (x - y).abs() < (eps * y).abs()
     }
 
     #[test]
     fn check_linking() {
-        let input : [f32; 3] = [1.0,2.0,3.0];
-        let mut output : [f32; 3] = [0.0, 0.0, 0.0];
-        let factor: f32 = 5.0;
-        // multiply each element in [1,2,3] by 5
+        let input = [1.0, 2.0, 3.0];
+        let factor = 5.0;
+        let mut output = [0.0, 0.0, 0.0];
         unsafe {
             vDSP_vsmul(input.as_ptr(), 1, &factor, output.as_mut_ptr(), 1, 3);
         }
@@ -46,5 +44,4 @@ mod tests {
         assert!(approx_eq(output[1], 10.0));
         assert!(approx_eq(output[2], 15.0));
     }
-
 }


### PR DESCRIPTION
Hi,


The pull request updates `libc` used for testing. I’ve also checked the definition of `vDSP_vsmul` in

```
/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Headers/vDSP.h
```


Best,
Ivan